### PR TITLE
Support reading date type TIMESTAMP(9)

### DIFF
--- a/src/main/java/io/trino/plugin/db2/DB2Client.java
+++ b/src/main/java/io/trino/plugin/db2/DB2Client.java
@@ -44,6 +44,7 @@ import static com.google.common.base.Verify.verify;
 import static io.trino.plugin.jdbc.JdbcErrorCode.JDBC_ERROR;
 import static io.trino.plugin.jdbc.StandardColumnMappings.longTimestampWriteFunction;
 import static io.trino.plugin.jdbc.StandardColumnMappings.timestampWriteFunction;
+import static io.trino.plugin.jdbc.StandardColumnMappings.timestampWriteFunctionUsingSqlTimestamp;
 import static io.trino.plugin.jdbc.StandardColumnMappings.toLongTimestamp;
 import static io.trino.plugin.jdbc.StandardColumnMappings.toTrinoTimestamp;
 import static io.trino.plugin.jdbc.StandardColumnMappings.varcharWriteFunction;
@@ -118,7 +119,7 @@ public class DB2Client
             return ColumnMapping.longMapping(
                     timestampType,
                     timestampReadFunction(timestampType),
-                    timestampWriteFunction(timestampType));
+                    timestampWriteFunctionUsingSqlTimestamp(timestampType));
         }
         checkArgument(timestampType.getPrecision() <= MAX_LOCAL_DATE_TIME_PRECISION, "Precision is out of range: %s", timestampType.getPrecision());
         return ColumnMapping.objectMapping(


### PR DESCRIPTION
Supports #75

## Progress

1. Uses support JDBC API to support read date type `TIMESTAMP(9)`. see https://github.com/IBM/trino-db2/issues/75#issuecomment-833842286
2. Supports read/write date type `TIMESTAMP` with precision up to `6`.

## Problem

It still can not write date in type `TIMESTAMP(9)` into any Db2 table b/c of this exception:

```
2021-05-07T02:32:10.711Z        ERROR   remote-task-callback-10 io.trino.execution.StageStateMachine    Stage 20210507_023206_00010_ruwj2.1 failed
io.trino.spi.TrinoException: [jcc][1091][10824][4.25.13] Invalid data conversion: Parameter instance 2021-05-05T21:49:22.400803 is invalid for the requested conversion. ERRORCODE=-4461, SQLSTATE=42815
        at io.trino.plugin.jdbc.JdbcPageSink.appendPage(JdbcPageSink.java:124)
        at io.trino.operator.TableWriterOperator.addInput(TableWriterOperator.java:257)
        at io.trino.operator.Driver.processInternal(Driver.java:392)
        at io.trino.operator.Driver.lambda$processFor$9(Driver.java:291)
        at io.trino.operator.Driver.tryWithLock(Driver.java:683)
        at io.trino.operator.Driver.processFor(Driver.java:284)
        at io.trino.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:1075)
        at io.trino.execution.executor.PrioritizedSplitRunner.process(PrioritizedSplitRunner.java:163)
        at io.trino.execution.executor.TaskExecutor$TaskRunner.run(TaskExecutor.java:484)
        at io.trino.$gen.Trino_356____20210507_022833_2.run(Unknown Source)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: com.ibm.db2.jcc.am.SqlSyntaxErrorException: [jcc][1091][10824][4.25.13] Invalid data conversion: Parameter instance 2021-05-05T21:49:22.400803 is invalid for the requested conversion. ERRORCODE=-4461, SQLSTATE=42815
        at com.ibm.db2.jcc.am.b6.a(b6.java:810)
        at com.ibm.db2.jcc.am.b6.a(b6.java:66)
        at com.ibm.db2.jcc.am.b6.a(b6.java:116)
        at com.ibm.db2.jcc.am.k4.c(k4.java:2686)
        at com.ibm.db2.jcc.am.k4.setObject(k4.java:2465)
        at io.trino.plugin.jdbc.StandardColumnMappings.lambda$longTimestampWriteFunction$27(StandardColumnMappings.java:535)
        at io.trino.plugin.jdbc.ObjectWriteFunction$1.set(ObjectWriteFunction.java:48)
        at io.trino.plugin.jdbc.JdbcPageSink.appendColumn(JdbcPageSink.java:156)
        at io.trino.plugin.jdbc.JdbcPageSink.appendPage(JdbcPageSink.java:109)
        ... 12 more
```